### PR TITLE
Admin Restock

### DIFF
--- a/module_constants.py
+++ b/module_constants.py
@@ -568,6 +568,8 @@ max_scene_prop_instance_id            = 10000 # when trying to loop over all pro
 max_food_amount                       = 100
 max_hit_points_percent                = 200
 
+admin_restock_amount                  = 10 # amount admin restocks pile by for each use
+
 all_items_begin = "itm_tattered_headcloth"
 all_items_end = "itm_all_items_end"
 

--- a/module_constants.py
+++ b/module_constants.py
@@ -568,7 +568,7 @@ max_scene_prop_instance_id            = 10000 # when trying to loop over all pro
 max_food_amount                       = 100
 max_hit_points_percent                = 200
 
-admin_restock_amount                  = 10 # amount admin restocks pile by for each use
+admin_restock_amount                  = 5 # amount admin restocks pile by for each use
 
 all_items_begin = "itm_tattered_headcloth"
 all_items_end = "itm_all_items_end"

--- a/module_scripts.py
+++ b/module_scripts.py
@@ -7695,7 +7695,17 @@ scripts.extend([
     (agent_get_wielded_item, ":shield_item_id", ":agent_id", 1),
     (item_get_type, ":item_type", ":item_id"),
     (assign, ":fail", 0),
-    (try_begin), # if the item is wielded or worn, try selling it
+    (try_begin), # if the item is an admin scalpol
+      (eq, ":weapon_item_id", "itm_admin_scalpel"),
+      (player_is_admin, ":player_id"),
+      (player_slot_eq, ":player_id", slot_player_admin_no_all_items, 0),
+      (val_add, ":stock_count", admin_restock_amount),
+      (str_store_item_name, s4, ":item_id"),
+      (str_store_string, s3, "str_log_admin_cheat_item"),
+      (str_store_player_username, s0, ":player_id"),
+      (player_get_unique_id, reg0, ":player_id"),
+      (server_add_message_to_log, "str_log_admin_target_self"),
+    (else_try), # if the item is wielded or worn, try selling it
       (this_or_next|eq, ":weapon_item_id", ":item_id"),
       (this_or_next|eq, ":shield_item_id", ":item_id"),
       (is_between, ":item_type", itp_type_head_armor, itp_type_hand_armor + 1),

--- a/module_scripts.py
+++ b/module_scripts.py
@@ -7701,7 +7701,7 @@ scripts.extend([
       (player_slot_eq, ":player_id", slot_player_admin_no_all_items, 0),
       (val_add, ":stock_count", admin_restock_amount),
       (str_store_item_name, s4, ":item_id"),
-      (str_store_string, s3, "str_log_admin_cheat_item"),
+      (str_store_string, s3, "str_log_admin_restocked_s4"),
       (str_store_player_username, s0, ":player_id"),
       (player_get_unique_id, reg0, ":player_id"),
       (server_add_message_to_log, "str_log_admin_target_self"),

--- a/module_strings.py
+++ b/module_strings.py
@@ -342,7 +342,7 @@ We apologize sincerely if you contributed your suggestions and feedback but were
   ("log_admin_lock_faction", "{s4}locked faction {s5}"),
   ("log_admin_cheat_money", "took {reg0} gold"),
   ("log_admin_cheat_item", "took item '{s4}'"),
-  ("log_admin_restocked_s4", "restocked a stockpile of '{s4}s'"),
+  ("log_admin_restocked_s4", "restocked a stockpile of '{s4}'s"),
 
   ("poll_change_scene", "Change scene to {s1}"),
   ("poll_kick_player", "Kick player {s1}"),

--- a/module_strings.py
+++ b/module_strings.py
@@ -342,6 +342,7 @@ We apologize sincerely if you contributed your suggestions and feedback but were
   ("log_admin_lock_faction", "{s4}locked faction {s5}"),
   ("log_admin_cheat_money", "took {reg0} gold"),
   ("log_admin_cheat_item", "took item '{s4}'"),
+  ("log_admin_restocked_s4", "restocked stockpile {s4}"),
 
   ("poll_change_scene", "Change scene to {s1}"),
   ("poll_kick_player", "Kick player {s1}"),

--- a/module_strings.py
+++ b/module_strings.py
@@ -342,7 +342,7 @@ We apologize sincerely if you contributed your suggestions and feedback but were
   ("log_admin_lock_faction", "{s4}locked faction {s5}"),
   ("log_admin_cheat_money", "took {reg0} gold"),
   ("log_admin_cheat_item", "took item '{s4}'"),
-  ("log_admin_restocked_s4", "restocked stockpile {s4}"),
+  ("log_admin_restocked_s4", "restocked a stockpile of '{s4}s'"),
 
   ("poll_change_scene", "Change scene to {s1}"),
   ("poll_kick_player", "Kick player {s1}"),


### PR DESCRIPTION
Admins can now restock by pressing F on stockpile with Admin Scalpel equipt.

Restocks are logged.