### PR TITLE
Sell Delay

### DIFF
--- a/module_constants.py
+++ b/module_constants.py
@@ -245,6 +245,8 @@ slot_scene_prop_inventory_mod_end     = slot_scene_prop_inventory_obj_begin
 slot_scene_prop_inventory_obj_end     = slot_scene_prop_inventory_mesh_begin
 inventory_count_maximum               = slot_scene_prop_inventory_item_0 - slot_scene_prop_inventory_begin
 
+slot_scene_prop_use_time              = 55
+
 corpse_inventory_slots                = 5 # coded into the module so values are the same on the server and clients
 corpse_inventory_max_length           = 100
 

--- a/module_scene_props.py
+++ b/module_scene_props.py
@@ -130,7 +130,7 @@ def spr_buy_item_triggers(item_id, pos_offset=(5,0,2), rotate=(0,0,0), use_strin
   spr_apply_pos_offset(buy_trigger[1], pos_offset, rotate)
   if len(resources) > 0:
     buy_trigger[1].extend([
-        (store_mission_timer_a, ":time"),
+        (store_mission_timer_a_msec, ":time"),
         (scene_prop_get_slot, ":use_time", ":instance_id", slot_scene_prop_use_time),
         (try_begin),
             (ge, ":time", ":use_time"),
@@ -144,8 +144,8 @@ def spr_buy_item_triggers(item_id, pos_offset=(5,0,2), rotate=(0,0,0), use_strin
 
   start_use = (ti_on_scene_prop_start_use,
      [(store_trigger_param_2, ":instance_id"),
-      (store_mission_timer_a, ":time"),
-      (val_add, ":time", 1),
+      (store_mission_timer_a_msec, ":time"),
+      (val_add, ":time", 250),
       (scene_prop_set_slot, ":instance_id", slot_scene_prop_use_time, ":time"),
   ])
 


### PR DESCRIPTION
Added sell delay to avoid accidental sells. You must now hold down for 1 seconds before releasing to buy or sell a weapon.

@DekkersNL what do you think of this?