### PR TITLE
Horses through Teleport Doors

### DIFF
--- a/module_scene_props.py
+++ b/module_scene_props.py
@@ -258,8 +258,8 @@ def spr_buy_banner_triggers(banner_item_begin, mercenary=False, use_string="str_
   return [init_trigger, spr_call_script_use_trigger("script_cf_buy_banner")]
 
 # Teleport to a linked door of the same scene prop type. 'pos_offset' specifies the relative position from each door that the character will be moved to.
-def spr_teleport_door_triggers(pos_offset=(0,0,0), pickable=1):
-  triggers = [spr_call_script_use_trigger("script_cf_use_teleport_door", pos_offset[0], pos_offset[1], pos_offset[2], pickable),
+def spr_teleport_door_triggers(pos_offset=(0,0,0), pickable=1, horse_can_tp=0):
+  triggers = [spr_call_script_use_trigger("script_cf_use_teleport_door", pos_offset[0], pos_offset[1], pos_offset[2], pickable, horse_can_tp),
     [link_scene_prop, link_scene_prop_self]]
   if pickable == 1:
     triggers.append(spr_call_script_cancel_use_trigger("script_cf_lock_teleport_door"))
@@ -2935,6 +2935,17 @@ scene_props = [
   ("pw_door_teleport_inset_c",spr_use_time(1),"pw_teleport_door_c","bo_pw_teleport_door_a", spr_teleport_door_triggers(pos_offset=(0,50,0))),
   ("pw_door_teleport_invisible",sokf_invisible|spr_use_time(1),"pw_invisible_door","bo_pw_invisible_door", spr_teleport_door_triggers(pos_offset=(0,50,0))),
   ("pw_door_teleport_invisible_not_pickable",sokf_invisible|spr_use_time(1),"pw_invisible_door","bo_pw_invisible_door", spr_teleport_door_triggers(pos_offset=(0,50,0), pickable=0)),
+
+  ("pw_door_teleport_small_arch_a_horse",spr_use_time(1),"tutorial_door_a","bo_tutorial_door_a", spr_teleport_door_triggers(pos_offset=(-55,50,-98), horse_can_tp=1)),
+  ("pw_door_teleport_square_a_horse",spr_use_time(1),"tutorial_door_b","bo_tutorial_door_b", spr_teleport_door_triggers(pos_offset=(70,50,0), horse_can_tp=1)),
+  ("pw_door_teleport_arch_a_horse",spr_use_time(1),"dungeon_door_direction_a","bo_dungeon_door_direction_a", spr_teleport_door_triggers(pos_offset=(100,0,-230), horse_can_tp=1)),
+  ("pw_door_teleport_roof_horse",spr_use_time(1),"house_roof_door","bo_house_roof_door", spr_teleport_door_triggers(pos_offset=(0,0,100), horse_can_tp=1)),
+  ("pw_door_teleport_inset_a_horse",spr_use_time(1),"pw_teleport_door_a","bo_pw_teleport_door_a", spr_teleport_door_triggers(pos_offset=(0,50,0), horse_can_tp=1)),
+  ("pw_door_teleport_inset_b_horse",spr_use_time(1),"pw_teleport_door_b","bo_pw_teleport_door_a", spr_teleport_door_triggers(pos_offset=(0,50,0), horse_can_tp=1)),
+  ("pw_door_teleport_inset_c_horse",spr_use_time(1),"pw_teleport_door_c","bo_pw_teleport_door_a", spr_teleport_door_triggers(pos_offset=(0,50,0), horse_can_tp=1)),
+  ("pw_door_teleport_invisible_horse",sokf_invisible|spr_use_time(1),"pw_invisible_door","bo_pw_invisible_door", spr_teleport_door_triggers(pos_offset=(0,50,0), horse_can_tp=1)),
+  ("pw_door_teleport_invisible_not_pickable_horse",sokf_invisible|spr_use_time(1),"pw_invisible_door","bo_pw_invisible_door", spr_teleport_door_triggers(pos_offset=(0,50,0), pickable=0, horse_can_tp=1)),
+
   ("pw_door_rotate_a",spr_rotate_door_flags(1),"castle_f_sally_door_a","bo_castle_f_sally_door_a", spr_rotate_door_triggers(hit_points=5000)),
   ("pw_door_rotate_b",spr_rotate_door_flags(1),"castle_e_sally_door_a","bo_castle_e_sally_door_a_fixed", spr_rotate_door_triggers(hit_points=5000)),
   ("pw_door_rotate_c",spr_rotate_door_flags(1),"castle_f_door_a","bo_castle_f_door_a_fixed", spr_rotate_door_triggers(hit_points=5000)),

--- a/module_scripts.py
+++ b/module_scripts.py
@@ -7037,6 +7037,11 @@ scripts.extend([
     (position_move_x, pos1, ":x_offset"),
     (position_move_y, pos1, ":y_offset"),
     (position_move_z, pos1, ":z_offset"),
+    (try_begin),
+      (agent_get_horse, ":horse_agent_id", ":agent_id"),
+      (gt, ":horse_agent_id", -1),
+      (assign, ":agent_id", ":horse_agent_id"),
+    (try_end),
     (agent_set_position, ":agent_id", pos1),
     ]),
 

--- a/module_scripts.py
+++ b/module_scripts.py
@@ -6998,6 +6998,7 @@ scripts.extend([
     (store_script_param, ":y_offset", 4), # position offset relative to the linked door that the agent is moved to
     (store_script_param, ":z_offset", 5),
     (store_script_param, ":is_pickable", 6),
+    (store_script_param, ":horse_can_tp", 7),
 
     (scene_prop_get_slot, ":linked_door_instance_id", ":instance_id", slot_scene_prop_linked_scene_prop),
     (gt, ":linked_door_instance_id", 0),
@@ -7038,6 +7039,7 @@ scripts.extend([
     (position_move_y, pos1, ":y_offset"),
     (position_move_z, pos1, ":z_offset"),
     (try_begin),
+      (eq, ":horse_can_tp", 1),
       (agent_get_horse, ":horse_agent_id", ":agent_id"),
       (gt, ":horse_agent_id", -1),
       (assign, ":agent_id", ":horse_agent_id"),


### PR DESCRIPTION
Horses can now go through teleport doors, which allows them to get out of spawns.